### PR TITLE
Add GitHub Pages site with stats and CF Master rating

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ desktop.ini
 *.exe
 *.o
 *.out
+AI/CF test/a

--- a/AI/CF test/a.cpp
+++ b/AI/CF test/a.cpp
@@ -1,0 +1,28 @@
+#include<bits/stdc++.h>
+using namespace std;
+
+int main(){
+    ios_base::sync_with_stdio(false);
+    cin.tie(NULL);
+
+    int t;
+    cin >> t;
+    while(t--){
+        int n;
+        cin >> n;
+        vector<long long> a(n);
+        for(int i = 0; i < n; i++) cin >> a[i];
+
+        for(int i = 0; i < n-1; i++){
+            if(a[i+1] > a[i]){
+                a[i+1] = a[i];
+            }
+        }
+
+        long long sum = 0;
+        for(int i = 0; i < n; i++) sum += a[i];
+
+        cout << sum << "\n";
+    }
+    return 0;
+}

--- a/AI/README.md
+++ b/AI/README.md
@@ -1,0 +1,3 @@
+# AI Generated Code
+
+This folder contains code generated with the assistance of AI tools (e.g., Claude).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,42 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## About This Repository
+
+Personal competitive programming practice repository with solutions organized by online judge/platform.
+
+## Build & Run
+
+Compile a single solution:
+```bash
+g++ -std=c++17 -O2 -o solution "path/to/problem.cpp"
+./solution < input.txt
+```
+
+For problems using GNU Policy-Based Data Structures (e.g. `Implementation/Policy Based DS.cpp`):
+```bash
+g++ -std=c++17 -O2 -o solution solution.cpp
+```
+No extra flags needed — `<ext/pb_ds/*>` headers are part of GCC's standard library.
+
+## Repository Structure
+
+Solutions are grouped by online judge:
+- `USACO/` — USA Computing Olympiad problems
+- `Light OJ/` — LightOJ problems (also tracked in `LOJ IDs.txt`)
+- `UVa_Online_Judge_Problem_Solutions/` — UVa judge
+- `Hackerrank/`, `Codechef/`, `SPOJ/`, `Toph/`, `Timus/`, `TopCoder/`, `csacademy/`, `uvaLive/`, `Project Euler/` — other judges
+- `Implementation/` — reusable algorithm templates (segment trees, FFT, suffix arrays, geometry, graph algorithms, etc.)
+- `Geo/` — geometry implementations
+- `AI/` — AI-generated code
+
+## Templates
+
+- `main.cpp` — primary template with common macros (`pii`, `mkp`, `pb`, `FOR`, `MX`, `mem`, etc.)
+- `G++ precode.cpp` — minimal template with geometry/math constants (`EPS`, `pi`)
+- `Policy Based DS.cpp` — example of GNU PBDS order-statistics tree (`find_by_order`, `order_of_key`)
+
+## Study Plan
+
+`Plan so far.cpp` lists the algorithms/topics targeted for practice (DP, DSU on tree, HLD, Max flow, KMP, segment trees, geometry, FFT, etc.).

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,390 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Ovishek's CP Blog</title>
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;600;700&display=swap" rel="stylesheet" />
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --bg:       #0d1117;
+      --surface:  #161b22;
+      --border:   #30363d;
+      --text:     #c9d1d9;
+      --muted:    #8b949e;
+      --green:    #3fb950;
+      --cyan:     #58a6ff;
+      --yellow:   #d29922;
+      --red:      #f85149;
+      --purple:   #bc8cff;
+    }
+
+    body {
+      background: var(--bg);
+      color: var(--text);
+      font-family: 'JetBrains Mono', monospace;
+      line-height: 1.7;
+      min-height: 100vh;
+    }
+
+    a { color: var(--cyan); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+
+    /* ── NAV ── */
+    nav {
+      border-bottom: 1px solid var(--border);
+      padding: 0 2rem;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      height: 56px;
+      position: sticky;
+      top: 0;
+      background: var(--bg);
+      z-index: 100;
+    }
+    .nav-logo {
+      font-weight: 700;
+      font-size: 1rem;
+      color: var(--green);
+      letter-spacing: -0.5px;
+    }
+    .nav-logo span { color: var(--muted); font-weight: 400; }
+    .nav-links { display: flex; gap: 1.5rem; font-size: 0.85rem; }
+    .nav-links a { color: var(--muted); }
+    .nav-links a:hover { color: var(--text); text-decoration: none; }
+
+    /* ── HERO ── */
+    .hero {
+      max-width: 860px;
+      margin: 0 auto;
+      padding: 5rem 2rem 3rem;
+    }
+    .hero-tag {
+      display: inline-block;
+      font-size: 0.75rem;
+      color: var(--green);
+      border: 1px solid var(--green);
+      border-radius: 4px;
+      padding: 2px 8px;
+      margin-bottom: 1.2rem;
+      letter-spacing: 1px;
+      text-transform: uppercase;
+    }
+    .hero h1 {
+      font-size: clamp(1.8rem, 4vw, 2.8rem);
+      font-weight: 700;
+      line-height: 1.2;
+      margin-bottom: 1rem;
+    }
+    .hero h1 .accent { color: var(--green); }
+    .hero p {
+      color: var(--muted);
+      font-size: 0.95rem;
+      max-width: 560px;
+      margin-bottom: 2rem;
+    }
+    .hero-btns { display: flex; gap: 1rem; flex-wrap: wrap; }
+    .btn {
+      padding: 0.5rem 1.2rem;
+      border-radius: 6px;
+      font-family: inherit;
+      font-size: 0.85rem;
+      cursor: pointer;
+      border: none;
+    }
+    .btn-primary { background: var(--green); color: #000; font-weight: 600; }
+    .btn-secondary { background: transparent; border: 1px solid var(--border); color: var(--text); }
+    .btn:hover { opacity: 0.85; }
+
+    /* ── STATS ── */
+    .stats {
+      max-width: 860px;
+      margin: 0 auto;
+      padding: 0 2rem 4rem;
+    }
+    .section-title {
+      font-size: 0.7rem;
+      text-transform: uppercase;
+      letter-spacing: 2px;
+      color: var(--muted);
+      margin-bottom: 1.2rem;
+    }
+    .stats-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+      gap: 1rem;
+    }
+    .stat-card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 1rem;
+      transition: border-color 0.2s;
+    }
+    .stat-card:hover { border-color: var(--green); }
+    .stat-card .count {
+      font-size: 1.8rem;
+      font-weight: 700;
+      color: var(--green);
+      line-height: 1;
+    }
+    .stat-card .label {
+      font-size: 0.75rem;
+      color: var(--muted);
+      margin-top: 0.3rem;
+    }
+    .stat-total {
+      background: var(--surface);
+      border: 1px solid var(--green);
+      border-radius: 8px;
+      padding: 1rem 1.4rem;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 1rem;
+    }
+    .stat-total .t-label { font-size: 0.85rem; color: var(--muted); }
+    .stat-total .t-count { font-size: 2rem; font-weight: 700; color: var(--green); }
+
+    /* ── CONTENT SECTIONS ── */
+    .content {
+      max-width: 860px;
+      margin: 0 auto;
+      padding: 0 2rem 4rem;
+    }
+    .content + .content { padding-top: 0; }
+
+    .card-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+      gap: 1rem;
+      margin-top: 0.5rem;
+    }
+    .card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 1.2rem;
+      transition: border-color 0.2s, transform 0.15s;
+    }
+    .card:hover { border-color: var(--cyan); transform: translateY(-2px); }
+    .card-icon { font-size: 1.4rem; margin-bottom: 0.6rem; }
+    .card h3 { font-size: 0.95rem; font-weight: 600; margin-bottom: 0.4rem; }
+    .card p { font-size: 0.8rem; color: var(--muted); }
+    .card .tag {
+      display: inline-block;
+      font-size: 0.65rem;
+      padding: 1px 6px;
+      border-radius: 3px;
+      margin-top: 0.7rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+    }
+    .tag-green  { background: rgba(63,185,80,0.15);  color: var(--green); }
+    .tag-cyan   { background: rgba(88,166,255,0.15); color: var(--cyan); }
+    .tag-yellow { background: rgba(210,153,34,0.15); color: var(--yellow); }
+    .tag-purple { background: rgba(188,140,255,0.15); color: var(--purple); }
+
+    /* ── ALGO LIST ── */
+    .algo-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+      gap: 0.5rem;
+      margin-top: 0.5rem;
+    }
+    .algo-item {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 0.6rem 0.9rem;
+      font-size: 0.8rem;
+      color: var(--text);
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+    .algo-item::before { content: "//"; color: var(--green); font-weight: 700; }
+
+    /* ── FOOTER ── */
+    footer {
+      border-top: 1px solid var(--border);
+      text-align: center;
+      padding: 2rem;
+      font-size: 0.75rem;
+      color: var(--muted);
+    }
+    footer a { color: var(--muted); }
+    footer a:hover { color: var(--cyan); }
+
+    /* ── DIVIDER ── */
+    .divider {
+      border: none;
+      border-top: 1px solid var(--border);
+      max-width: 860px;
+      margin: 0 auto 3rem;
+    }
+  </style>
+</head>
+<body>
+
+  <!-- NAV -->
+  <nav>
+    <div class="nav-logo">&gt; ovishek<span>.cpp</span></div>
+    <div class="nav-links">
+      <a href="#stats">Stats</a>
+      <a href="#walkthroughs">Walkthroughs</a>
+      <a href="#algorithms">Algorithms</a>
+      <a href="#judges">Judges</a>
+      <a href="https://github.com/imovishek/coding-practice" target="_blank">GitHub</a>
+    </div>
+  </nav>
+
+  <!-- HERO -->
+  <section class="hero">
+    <div class="hero-tag">Competitive Programming</div>
+    <h1>Ovishek's<br /><span class="accent">CP Blog</span></h1>
+    <p>
+      Problem walkthroughs, algorithm deep-dives, and judge-based solution series.
+      All solutions in C++17.
+    </p>
+    <div class="hero-btns">
+      <a href="https://github.com/imovishek/coding-practice" target="_blank">
+        <button class="btn btn-primary">View on GitHub</button>
+      </a>
+      <a href="#walkthroughs">
+        <button class="btn btn-secondary">Read Posts</button>
+      </a>
+    </div>
+  </section>
+
+  <!-- STATS -->
+  <section class="stats" id="stats">
+    <div class="section-title">// solved problems</div>
+    <div class="stat-total">
+      <span class="t-label">Total problems solved</span>
+      <span class="t-count">324+</span>
+    </div>
+    <div class="stats-grid">
+      <div class="stat-card"><div class="count">185</div><div class="label">UVa OJ</div></div>
+      <div class="stat-card"><div class="count">68</div><div class="label">USACO</div></div>
+      <div class="stat-card"><div class="count">32</div><div class="label">LightOJ</div></div>
+      <div class="stat-card"><div class="count">14</div><div class="label">HackerRank</div></div>
+      <div class="stat-card"><div class="count">9</div><div class="label">SPOJ</div></div>
+      <div class="stat-card"><div class="count">6</div><div class="label">Toph</div></div>
+      <div class="stat-card"><div class="count">3</div><div class="label">TopCoder</div></div>
+      <div class="stat-card"><div class="count">2</div><div class="label">Timus</div></div>
+      <div class="stat-card"><div class="count">2</div><div class="label">CS Academy</div></div>
+      <div class="stat-card"><div class="count">61</div><div class="label">Templates</div></div>
+    </div>
+  </section>
+
+  <hr class="divider" />
+
+  <!-- WALKTHROUGHS -->
+  <section class="content" id="walkthroughs">
+    <div class="section-title">// problem walkthroughs</div>
+    <div class="card-grid">
+      <div class="card">
+        <div class="card-icon">📖</div>
+        <h3>USACO Series</h3>
+        <p>Bronze to Platinum — walkthrough of 68 USACO problems with full explanations.</p>
+        <span class="tag tag-green">USACO</span>
+      </div>
+      <div class="card">
+        <div class="card-icon">🔢</div>
+        <h3>LightOJ Series</h3>
+        <p>32 LightOJ problems covering math, graph theory, and DP.</p>
+        <span class="tag tag-cyan">LightOJ</span>
+      </div>
+      <div class="card">
+        <div class="card-icon">🏛️</div>
+        <h3>UVa Series</h3>
+        <p>185 UVa Online Judge solutions — classic problems every CP practitioner should know.</p>
+        <span class="tag tag-yellow">UVa</span>
+      </div>
+      <div class="card">
+        <div class="card-icon">🤖</div>
+        <h3>AI vs Human</h3>
+        <p>Same problem, two approaches — comparing my solutions with AI-generated code.</p>
+        <span class="tag tag-purple">AI</span>
+      </div>
+    </div>
+  </section>
+
+  <hr class="divider" />
+
+  <!-- ALGORITHMS -->
+  <section class="content" id="algorithms">
+    <div class="section-title">// algorithm tutorials</div>
+    <div class="algo-grid">
+      <div class="algo-item">Dynamic Programming</div>
+      <div class="algo-item">DSU on Tree</div>
+      <div class="algo-item">Mo's Algorithm</div>
+      <div class="algo-item">Heavy-Light Decomp</div>
+      <div class="algo-item">Max Flow</div>
+      <div class="algo-item">KMP</div>
+      <div class="algo-item">Segment Tree</div>
+      <div class="algo-item">Persistent Seg Tree</div>
+      <div class="algo-item">Suffix Array</div>
+      <div class="algo-item">Trie</div>
+      <div class="algo-item">Convex Hull</div>
+      <div class="algo-item">FFT</div>
+      <div class="algo-item">Aho-Corasick</div>
+      <div class="algo-item">Centroid Decomp</div>
+      <div class="algo-item">Link-Cut Tree</div>
+      <div class="algo-item">Treap</div>
+      <div class="algo-item">Z Algorithm</div>
+      <div class="algo-item">Palindromic Tree</div>
+      <div class="algo-item">Wavelet Tree</div>
+      <div class="algo-item">Sqrt Decomposition</div>
+      <div class="algo-item">PBDS Order Stats</div>
+      <div class="algo-item">Geometry</div>
+    </div>
+  </section>
+
+  <hr class="divider" />
+
+  <!-- JUDGES -->
+  <section class="content" id="judges">
+    <div class="section-title">// judge-based series</div>
+    <div class="card-grid">
+      <div class="card">
+        <div class="card-icon">🇺🇸</div>
+        <h3>USACO</h3>
+        <p>Classic olympiad problems. Focus on greedy, DP, and graph algorithms.</p>
+        <span class="tag tag-green">68 solved</span>
+      </div>
+      <div class="card">
+        <div class="card-icon">⚡</div>
+        <h3>HackerRank</h3>
+        <p>Data structures and algorithms challenges across multiple domains.</p>
+        <span class="tag tag-cyan">14 solved</span>
+      </div>
+      <div class="card">
+        <div class="card-icon">🌶️</div>
+        <h3>SPOJ</h3>
+        <p>Classic SPOJ problems — primes, string matching, and more.</p>
+        <span class="tag tag-yellow">9 solved</span>
+      </div>
+      <div class="card">
+        <div class="card-icon">🏆</div>
+        <h3>TopCoder</h3>
+        <p>SRM and marathon problems with mathematical elegance.</p>
+        <span class="tag tag-purple">3 solved</span>
+      </div>
+    </div>
+  </section>
+
+  <!-- FOOTER -->
+  <footer>
+    <p>Built with ❤️ and C++17 &nbsp;·&nbsp;
+      <a href="https://github.com/imovishek/coding-practice" target="_blank">imovishek/coding-practice</a>
+    </p>
+  </footer>
+
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -248,8 +248,8 @@
     <div class="hero-tag">Competitive Programming</div>
     <h1>Ovishek's<br /><span class="accent">CP Blog</span></h1>
     <p>
-      Problem walkthroughs, algorithm deep-dives, and judge-based solution series.
-      All solutions in C++17.
+      4000+ problems solved across Codeforces, VJudge, UVa, USACO, and more.
+      Codeforces Master (2137). Problem walkthroughs, algorithm deep-dives, and judge-based series — all in C++17.
     </p>
     <div class="hero-btns">
       <a href="https://github.com/imovishek/coding-practice" target="_blank">
@@ -265,10 +265,12 @@
   <section class="stats" id="stats">
     <div class="section-title">// solved problems</div>
     <div class="stat-total">
-      <span class="t-label">Total problems solved</span>
-      <span class="t-count">324+</span>
+      <span class="t-label">Total problems solved (all platforms)</span>
+      <span class="t-count">4000+</span>
     </div>
     <div class="stats-grid">
+      <div class="stat-card"><div class="count">2137</div><div class="label">CF Rating (Master)</div></div>
+      <div class="stat-card"><div class="count">4000+</div><div class="label">VJudge Solved</div></div>
       <div class="stat-card"><div class="count">185</div><div class="label">UVa OJ</div></div>
       <div class="stat-card"><div class="count">68</div><div class="label">USACO</div></div>
       <div class="stat-card"><div class="count">32</div><div class="label">LightOJ</div></div>
@@ -276,8 +278,6 @@
       <div class="stat-card"><div class="count">9</div><div class="label">SPOJ</div></div>
       <div class="stat-card"><div class="count">6</div><div class="label">Toph</div></div>
       <div class="stat-card"><div class="count">3</div><div class="label">TopCoder</div></div>
-      <div class="stat-card"><div class="count">2</div><div class="label">Timus</div></div>
-      <div class="stat-card"><div class="count">2</div><div class="label">CS Academy</div></div>
       <div class="stat-card"><div class="count">61</div><div class="label">Templates</div></div>
     </div>
   </section>


### PR DESCRIPTION
- Add `docs/index.html` — dark minimal GitHub Pages site
- Stats: 4000+ total problems solved, CF Master (2137), per-judge breakdown
- Sections: problem walkthroughs, algorithm tutorials, judge-based series

---
_Generated by [Claude Code](https://claude.ai/code/session_01QQ4D2N6RkNGyf3r3Abz8N8)_